### PR TITLE
Fix logging.handlers import for Pylance

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,8 @@
 import logging
+import logging.handlers
+
 from collector.utils import setup_logging
+
 
 def test_setup_logging(tmp_path):
     log_file = tmp_path / "test.log"
@@ -7,4 +10,3 @@ def test_setup_logging(tmp_path):
     logger = logging.getLogger()
     assert any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
     assert any(isinstance(h, logging.handlers.RotatingFileHandler) for h in logger.handlers)
-


### PR DESCRIPTION
## Summary
- import `logging.handlers` in `tests/test_utils.py`

## Testing
- `pytest -q` *(fails: coverage < 80%)*

------
https://chatgpt.com/codex/tasks/task_e_685e5d71e988832cab20384b6b304b40