### PR TITLE
Enhance config validation

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import pytest
 import yaml
 
 from collector.config import load_config, save_config_template
@@ -26,3 +27,28 @@ def test_save_config_template(tmp_path):
     assert output.exists()
     data = yaml.safe_load(output.read_text())
     assert "database" in data and "logging" in data
+
+
+def test_load_config_ignores_extra_keys(tmp_path):
+    cfg_path = tmp_path / "extra.yaml"
+    cfg_path.write_text(
+        """
+        database:
+          path: sample.db
+          unknown: 123
+        """
+    )
+    cfg = load_config(str(cfg_path))
+    assert cfg.database.path == "sample.db"
+
+
+def test_validation_error(tmp_path):
+    cfg_path = tmp_path / "invalid.yaml"
+    cfg_path.write_text(
+        """
+        database:
+          backup_interval_hours: 0
+        """
+    )
+    with pytest.raises(ValueError):
+        load_config(str(cfg_path))


### PR DESCRIPTION
## Summary
- add field filtering and validation helpers for configuration
- validate config when loading
- ignore unknown keys in config files
- test config validation and field filtering

## Testing
- `ruff check tests/test_config.py collector/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e6844c6ec832cb305b125bc044f61