### PR TITLE
Resolve Pylance optional attribute warnings

### DIFF
--- a/collector/config.py
+++ b/collector/config.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 try:
     import yaml  # type: ignore
+    YamlError = getattr(yaml, "YAMLError", Exception)
 except ImportError:  # pragma: no cover - optional dependency
     import json
 
@@ -230,7 +231,7 @@ def load_config(config_path: Optional[str] = None) -> CollectorConfig:
                     f"Configuration file must contain a dictionary, got {type(config_data).__name__}"
                 )
 
-        except yaml.YAMLError as e:
+        except YamlError as e:
             raise ValueError(f"Invalid YAML in configuration file {config_path}: {e}")
         except (IOError, OSError) as e:
             raise ValueError(f"Cannot read configuration file {config_path}: {e}")

--- a/collector/search.py
+++ b/collector/search.py
@@ -130,7 +130,7 @@ class SearchEngine:
 
     @retry(
         stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=10) + wait_random(0, 2),
+        wait=wait_exponential(multiplier=1, min=2, max=10) + wait_random(0, 2),  # type: ignore[operator]
     )
     async def search_videos(self, query: str, max_results: int = 100) -> List[Dict]:
         """Search for videos using yt-dlp with error handling."""

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -222,3 +222,16 @@ def test_process_video_uses_music_metadata(monkeypatch):
 
     assert 0 <= scores["overall_score"] <= 1
     assert abs(scores["overall_score"] - expected_overall) < 1e-6
+
+
+def test_helpers_handle_missing_http_client():
+    cfg = CollectorConfig()
+    processor = VideoProcessor(cfg)
+
+    processor.http_client = None
+
+    ryd = asyncio.run(processor._get_ryd_data("abc123"))
+    music = asyncio.run(processor._get_music_metadata("a", "b"))
+
+    assert ryd == {"ryd_confidence": 0.0}
+    assert music == {"release_year_confidence": 0.0}


### PR DESCRIPTION
## Summary
- add `AsyncClientWithForceClose` wrapper to close httpx transport safely
- guard `None` http client in RYD and MusicBrainz helpers
- silence YAML and tenacity typing issues
- test helper behaviour when http client missing

## Testing
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e85d37794832ca6ef1293e96a458e