### PR TITLE
Fix ruff import order

### DIFF
--- a/tests/test_editable_install.py
+++ b/tests/test_editable_install.py
@@ -1,7 +1,7 @@
 import subprocess
 import sys
-from pathlib import Path
 import venv
+from pathlib import Path
 
 
 def test_editable_install(tmp_path):


### PR DESCRIPTION
## Summary
- sort imports in `tests/test_editable_install.py`

## Testing
- `ruff check tests/test_editable_install.py`
- `ruff check .`
- `pytest -q` *(fails: could not fetch build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e94886f3c832ca21db99dd421ae8a