### PR TITLE
Fix offline editable install test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ description = "Comprehensive tool for collecting karaoke video data from YouTube
 readme = "README.md"
 requires-python = ">=3.8"
 license = "MIT"
-include-package-data = true
 authors = [
     {name = "Karaoke Collector Team"},
 ]

--- a/tests/test_editable_install.py
+++ b/tests/test_editable_install.py
@@ -7,10 +7,22 @@ from pathlib import Path
 def test_editable_install(tmp_path):
     project_root = Path(__file__).resolve().parents[1]
     env_dir = tmp_path / "venv"
-    venv.EnvBuilder(with_pip=True).create(env_dir)
+    venv.EnvBuilder(with_pip=True, system_site_packages=True).create(env_dir)
     python = env_dir / ("Scripts" if sys.platform == "win32" else "bin") / "python"
-    cmd = [str(python), "-m", "pip", "install", "--no-index", "--no-deps", "-e", str(project_root) + "[dev]"]
+    cmd = [
+        str(python),
+        "-m",
+        "pip",
+        "install",
+        "--no-build-isolation",
+        "--no-index",
+        "--no-deps",
+        "-e",
+        str(project_root) + "[dev]",
+    ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
-    check = subprocess.run([str(python), "-c", "import karaoke_video_collector"], capture_output=True, text=True)
+    check = subprocess.run(
+        [str(python), "-c", "import karaoke_video_collector"], capture_output=True, text=True
+    )
     assert check.returncode == 0, check.stderr


### PR DESCRIPTION
## Summary
- fix editable install test by using system packages and disabling build isolation
- remove invalid `include-package-data` field from `pyproject.toml`

## Testing
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e96a0b230832c839e36f714d15abe