### PR TITLE
Improve fuzzy matcher robustness

### DIFF
--- a/collector/search/__init__.py
+++ b/collector/search/__init__.py
@@ -1,85 +1,145 @@
 """Search module for karaoke video discovery."""
 
-# Import original SearchEngine from the parent search.py for backward compatibility
-import sys
-import os
-
-# Add parent directory to path temporarily to import the original SearchEngine
-parent_dir = os.path.dirname(os.path.dirname(__file__))
-if parent_dir not in sys.path:
-    sys.path.insert(0, parent_dir)
-
+# Import SearchEngine implementation from the local module.
+# Older layouts expected `search.py` at the package root; we directly import the
+# packaged version for reliability.
 try:
-    from search import SearchEngine
-except ImportError:
-    # If that fails, try direct import
-    try:
-        import importlib.util
-        spec = importlib.util.spec_from_file_location("search", os.path.join(os.path.dirname(__file__), "..", "search.py"))
-        search_module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(search_module)
-        SearchEngine = search_module.SearchEngine
-    except Exception:
-        # Final fallback - create a wrapper
-        from .providers.youtube import YouTubeSearchProvider
-        from .providers.base import SearchResult
-        
-        class SearchEngine:
-            """Backward compatibility wrapper for original SearchEngine."""
-            def __init__(self, search_config, scraping_config):
-                self.search_config = search_config
-                self.scraping_config = scraping_config
-                self.youtube_provider = YouTubeSearchProvider(scraping_config)
-                
-            async def search_videos(self, query: str, max_results: int = 100) -> list:
-                """Search for videos using YouTube provider."""
-                results = await self.youtube_provider.search_videos(query, max_results)
-                # Convert SearchResult objects to dict format for backward compatibility
-                return [
-                    {
-                        "video_id": r.video_id,
-                        "url": r.url,
-                        "title": r.title,
-                        "channel": r.channel,
-                        "channel_id": r.channel_id,
-                        "duration": r.duration,
-                        "view_count": r.view_count,
-                        "upload_date": r.upload_date,
-                        "search_method": r.search_method,
-                        "search_query": r.search_query,
-                        "relevance_score": r.relevance_score,
-                    }
-                    for r in results
-                ]
-                
-            async def extract_channel_info(self, channel_url: str) -> dict:
-                """Extract channel information."""
-                return await self.youtube_provider.extract_channel_info(channel_url)
-                
-            async def extract_channel_videos(self, channel_url: str, max_videos=None, after_date=None) -> list:
-                """Extract videos from a channel."""
-                results = await self.youtube_provider.extract_channel_videos(channel_url, max_videos, after_date)
-                # Convert SearchResult objects to dict format for backward compatibility
-                return [
-                    {
-                        "video_id": r.video_id,
-                        "url": r.url,
-                        "title": r.title,
-                        "channel": r.channel,
-                        "channel_id": r.channel_id,
-                        "duration": r.duration,
-                        "view_count": r.view_count,
-                        "upload_date": r.upload_date,
-                        "search_method": r.search_method,
-                        "search_query": r.search_query,
-                        "relevance_score": r.relevance_score,
-                    }
-                    for r in results
-                ]
+    from ..search import SearchEngine
+except Exception:
+    # Final fallback - minimal wrapper using the YouTube provider only.
+    from .providers.youtube import YouTubeSearchProvider
+    from .providers.base import SearchResult
 
-# Clean up sys.path
-if parent_dir in sys.path:
-    sys.path.remove(parent_dir)
+    class SearchEngine:
+        """Backward compatibility wrapper for original SearchEngine."""
+
+        def __init__(self, search_config, scraping_config):
+            self.search_config = search_config
+            self.scraping_config = scraping_config
+            self.youtube_provider = YouTubeSearchProvider(scraping_config)
+
+        async def search_videos(self, query: str, max_results: int = 100) -> list:
+            """Search for videos using YouTube provider."""
+            results = await self.youtube_provider.search_videos(query, max_results)
+            # Convert SearchResult objects to dict format for backward compatibility
+            return [
+                {
+                    "video_id": r.video_id,
+                    "url": r.url,
+                    "title": r.title,
+                    "channel": r.channel,
+                    "channel_id": r.channel_id,
+                    "duration": r.duration,
+                    "view_count": r.view_count,
+                    "upload_date": r.upload_date,
+                    "search_method": r.search_method,
+                    "search_query": r.search_query,
+                    "relevance_score": r.relevance_score,
+                }
+                for r in results
+            ]
+
+        async def extract_channel_info(self, channel_url: str) -> dict:
+            """Extract channel information."""
+            return await self.youtube_provider.extract_channel_info(channel_url)
+
+        async def extract_channel_videos(
+            self, channel_url: str, max_videos=None, after_date=None
+        ) -> list:
+            """Extract videos from a channel."""
+            results = await self.youtube_provider.extract_channel_videos(
+                channel_url, max_videos, after_date
+            )
+            # Convert SearchResult objects to dict format for backward compatibility
+            return [
+                {
+                    "video_id": r.video_id,
+                    "url": r.url,
+                    "title": r.title,
+                    "channel": r.channel,
+                    "channel_id": r.channel_id,
+                    "duration": r.duration,
+                    "view_count": r.view_count,
+                    "upload_date": r.upload_date,
+                    "search_method": r.search_method,
+                    "search_query": r.search_query,
+                    "relevance_score": r.relevance_score,
+                }
+                for r in results
+            ]
+
+        def _is_likely_karaoke(self, title: str) -> bool:
+            karaoke_indicators = [
+                "karaoke",
+                "backing track",
+                "instrumental",
+                "sing along",
+                "minus one",
+                "playback",
+                "accompaniment",
+            ]
+            has_indicator = any(indicator in title for indicator in karaoke_indicators)
+            exclusions = [
+                "reaction",
+                "review",
+                "tutorial",
+                "lesson",
+                "how to",
+                "analysis",
+                "behind the scenes",
+                "interview",
+                "documentary",
+            ]
+            has_exclusion = any(exclusion in title for exclusion in exclusions)
+            return has_indicator and not has_exclusion
+
+        def _calculate_relevance_score(self, title: str, query: str) -> float:
+            title_lower = title.lower()
+            query_lower = query.lower()
+            score = 0.0
+            if query_lower in title_lower:
+                score += 1.0
+            query_terms = query_lower.split()
+            if query_terms:
+                matching_terms = sum(1 for term in query_terms if term in title_lower)
+                score += (matching_terms / len(query_terms)) * 0.5
+            quality_indicators = {
+                "hd": 0.2,
+                "4k": 0.3,
+                "high quality": 0.2,
+                "studio": 0.2,
+                "professional": 0.2,
+                "with lyrics": 0.3,
+                "guide vocals": 0.2,
+            }
+            for indicator, weight in quality_indicators.items():
+                if indicator in title_lower:
+                    score += weight
+            return min(score, 2.0)
+
+        def _parse_upload_date(self, upload_date: str):
+            from datetime import datetime
+
+            if not upload_date:
+                return None
+            try:
+                if len(upload_date) == 8 and upload_date.isdigit():
+                    return datetime.strptime(upload_date, "%Y%m%d")
+                elif len(upload_date) == 10 and upload_date.count("-") == 2:
+                    return datetime.strptime(upload_date, "%Y-%m-%d")
+                return None
+            except ValueError:
+                return None
+
+        def _is_video_after_date(self, upload_date: str, after_date: str) -> bool:
+            if not after_date or not upload_date:
+                return True
+            video_date = self._parse_upload_date(upload_date)
+            cutoff_date = self._parse_upload_date(after_date.replace("-", "")[:8])
+            if not video_date or not cutoff_date:
+                return True
+            return video_date > cutoff_date
+
 
 from .providers.base import SearchProvider, SearchResult
 from .providers.youtube import YouTubeSearchProvider
@@ -90,7 +150,7 @@ from .cache_manager import CacheManager
 __all__ = [
     "SearchEngine",  # Original for backward compatibility
     "SearchProvider",
-    "SearchResult", 
+    "SearchResult",
     "YouTubeSearchProvider",
     "FuzzyMatcher",
     "ResultRanker",

--- a/collector/search/fuzzy_matcher.py
+++ b/collector/search/fuzzy_matcher.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 try:
     import jellyfish  # type: ignore
+
     HAS_JELLYFISH = True
 except ImportError:
     HAS_JELLYFISH = False
@@ -20,7 +21,7 @@ except ImportError:
 @dataclass
 class FuzzyMatch:
     """Result of fuzzy matching operation."""
-    
+
     original: str
     matched: str
     score: float
@@ -32,95 +33,97 @@ class FuzzyMatch:
 
 class FuzzyMatcher:
     """Advanced fuzzy matching with multiple algorithms and normalization strategies."""
-    
-    def __init__(self, config=None):
+
+    def __init__(self, config: Optional[object] = None) -> None:
+        """Initialize the fuzzy matcher with optional configuration."""
         self.config = config or {}
-        
+
         # Handle different config types
-        if hasattr(config, 'fuzzy_matching'):
+        if hasattr(config, "fuzzy_matching"):
             # Handle structured config object
-            fuzzy_config = getattr(config, 'fuzzy_matching', {})
-            if hasattr(fuzzy_config, '__dict__'):
+            fuzzy_config = getattr(config, "fuzzy_matching", {})
+            if hasattr(fuzzy_config, "__dict__"):
                 fuzzy_config = fuzzy_config.__dict__
-        elif hasattr(config, '__dict__'):
-            # Handle other config objects 
-            fuzzy_config = getattr(config.__dict__, 'fuzzy_matching', {})
+        elif hasattr(config, "__dict__"):
+            # Handle other config objects
+            fuzzy_config = config.__dict__.get("fuzzy_matching", {})
         elif isinstance(config, dict):
             # Handle dict config
-            fuzzy_config = config.get('fuzzy_matching', {})
+            fuzzy_config = config.get("fuzzy_matching", {})
         else:
             fuzzy_config = {}
-        
+
         # Matching thresholds
         self.min_similarity_threshold = fuzzy_config.get("min_similarity", 0.7)
         self.min_phonetic_threshold = fuzzy_config.get("min_phonetic", 0.8)
         self.max_edit_distance = fuzzy_config.get("max_edit_distance", 3)
-        
+
         # Known normalization patterns
         self._load_normalization_patterns()
-        
+
         # Cache for expensive operations
         self._normalization_cache = {}
         self._soundex_cache = {}
         self._metaphone_cache = {}
-        
+
     def _load_normalization_patterns(self):
         """Load patterns for text normalization."""
-        
+
         # Common artist name variations
         self.artist_normalizations = {
             # Articles
-            r'^the\s+': '',
-            r'^a\s+': '',
-            r'^an\s+': '',
-            
+            r"^the\s+": "",
+            r"^a\s+": "",
+            r"^an\s+": "",
             # Punctuation and symbols
-            r'[&]': 'and',
-            r'[\.,\-_]': ' ',
-            r'[\'\""]': '',
-            r'\s+': ' ',
-            
+            r"[&]": "and",
+            r"[\.,\-_]": " ",
+            r'[\'\""]': "",
+            r"\s+": " ",
             # Common abbreviations
-            r'\bft\.?\b': 'featuring',
-            r'\bfeat\.?\b': 'featuring',
-            r'\bvs\.?\b': 'versus',
-            r'\bw/\b': 'with',
+            r"\bft\.?\b": "featuring",
+            r"\bfeat\.?\b": "featuring",
+            r"\bvs\.?\b": "versus",
+            r"\bw/\b": "with",
         }
-        
+
         # Common song title variations
         self.song_normalizations = {
             # Remove parentheticals that don't affect matching
-            r'\s*\([^)]*(?:remix|edit|version|mix|remaster)[^)]*\)': '',
-            r'\s*\([^)]*(?:live|acoustic|demo|instrumental)[^)]*\)': '',
-            r'\s*\[[^\]]*(?:remix|edit|version|mix|remaster)[^\]]*\]': '',
-            
+            r"\s*\([^)]*(?:remix|edit|version|mix|remaster)[^)]*\)": "",
+            r"\s*\([^)]*(?:live|acoustic|demo|instrumental)[^)]*\)": "",
+            r"\s*\[[^\]]*(?:remix|edit|version|mix|remaster)[^\]]*\]": "",
             # Normalize punctuation
-            r'[\'\""]': '',
-            r'[\-_]': ' ',
-            r'\s+': ' ',
+            r'[\'\""]': "",
+            r"[\-_]": " ",
+            r"\s+": " ",
         }
-        
+
         # Phonetically similar replacements
         self.phonetic_replacements = {
-            'ph': 'f',
-            'ck': 'k',
-            'qu': 'kw',
-            'tion': 'shun',
-            'sion': 'shun',
-            'c': 'k',  # context-dependent
+            "ph": "f",
+            "ck": "k",
+            "qu": "kw",
+            "tion": "shun",
+            "sion": "shun",
+            "c": "k",  # context-dependent
         }
-        
+
     def normalize_text(self, text: str, text_type: str = "general") -> str:
         """Normalize text for better matching."""
-        if text in self._normalization_cache:
-            return self._normalization_cache[text]
-            
+        if not isinstance(text, str):
+            text = str(text)
+
+        cache_key = (text_type, text)
+        if cache_key in self._normalization_cache:
+            return self._normalization_cache[cache_key]
+
         # Unicode normalization
-        normalized = unicodedata.normalize('NFKD', text.lower().strip())
-        
+        normalized = unicodedata.normalize("NFKD", text.lower().strip())
+
         # Remove accents
-        normalized = ''.join(c for c in normalized if not unicodedata.combining(c))
-        
+        normalized = "".join(c for c in normalized if not unicodedata.combining(c))
+
         # Apply type-specific normalizations
         patterns = {}
         if text_type == "artist":
@@ -129,97 +132,99 @@ class FuzzyMatcher:
             patterns = self.song_normalizations
         else:
             patterns = {**self.artist_normalizations, **self.song_normalizations}
-            
+
         for pattern, replacement in patterns.items():
             normalized = re.sub(pattern, replacement, normalized, flags=re.IGNORECASE)
-            
+
         normalized = normalized.strip()
-        self._normalization_cache[text] = normalized
+        self._normalization_cache[cache_key] = normalized
         return normalized
-        
+
     def calculate_similarity(self, text1: str, text2: str) -> float:
         """Calculate string similarity using multiple methods."""
         if not text1 or not text2:
             return 0.0
-            
+
         # Quick exact match check
         if text1.lower() == text2.lower():
             return 1.0
-            
+
         # Normalize both texts
         norm1 = self.normalize_text(text1)
         norm2 = self.normalize_text(text2)
-        
+
         if norm1 == norm2:
             return 0.95
-            
+
         # Use multiple similarity measures
         similarities = []
-        
+
         # 1. Sequence matcher (Ratcliff-Obershelp)
         seq_sim = SequenceMatcher(None, norm1, norm2).ratio()
         similarities.append(("sequence", seq_sim))
-        
+
         # 2. Jaro-Winkler similarity (if available)
         if HAS_JELLYFISH:
             jaro_sim = jellyfish.jaro_winkler_similarity(norm1, norm2)
             similarities.append(("jaro_winkler", jaro_sim))
-        
+
         # 3. Levenshtein distance normalized
         if HAS_JELLYFISH:
             lev_distance = jellyfish.levenshtein_distance(norm1, norm2)
             max_len = max(len(norm1), len(norm2))
             lev_sim = 1.0 - (lev_distance / max_len) if max_len > 0 else 0.0
             similarities.append(("levenshtein", lev_sim))
-        
+
         # 4. Token-based similarity for multi-word strings
-        if ' ' in norm1 or ' ' in norm2:
+        if " " in norm1 or " " in norm2:
             token_sim = self._calculate_token_similarity(norm1, norm2)
             similarities.append(("token", token_sim))
-            
+
         # Weighted average of similarities
         if not similarities:
             return 0.0
-            
+
         weights = {"sequence": 0.3, "jaro_winkler": 0.4, "levenshtein": 0.2, "token": 0.1}
         weighted_sum = sum(weights.get(method, 0.25) * score for method, score in similarities)
         total_weight = sum(weights.get(method, 0.25) for method, _ in similarities)
-        
+
         return weighted_sum / total_weight if total_weight > 0 else 0.0
-        
+
     def _calculate_token_similarity(self, text1: str, text2: str) -> float:
         """Calculate similarity based on token overlap."""
         tokens1 = set(text1.split())
         tokens2 = set(text2.split())
-        
+
         if not tokens1 or not tokens2:
             return 0.0
-            
+
         intersection = tokens1.intersection(tokens2)
         union = tokens1.union(tokens2)
-        
+
         # Jaccard similarity
         jaccard = len(intersection) / len(union) if union else 0.0
-        
+
         # Bonus for ordered similarity
         ordered_bonus = 0.0
         list1, list2 = text1.split(), text2.split()
-        if len(list1) == len(list2):
+        if len(list1) == len(list2) and len(list1) > 0:
             matches = sum(1 for a, b in zip(list1, list2) if a == b)
             ordered_bonus = matches / len(list1) * 0.2
-            
-        return min(jaccard + ordered_bonus, 1.0)
-        
+            ordered_bonus = min(ordered_bonus, 1.0 - jaccard)
+
+        return jaccard + ordered_bonus
+
     def phonetic_similarity(self, text1: str, text2: str) -> float:
-        """Calculate phonetic similarity using Soundex and Metaphone."""
-        if not HAS_JELLYFISH:
-            return 0.0
-            
+        """Calculate phonetic similarity using Soundex and Metaphone.
+
+        Falls back to simplified algorithms when :mod:`jellyfish` is unavailable.
+        """
+
         norm1 = self.normalize_text(text1)
         norm2 = self.normalize_text(text2)
-        
+
         similarities = []
-        
+
         # Soundex comparison
         try:
             soundex1 = self._get_soundex(norm1)
@@ -230,9 +235,9 @@ class FuzzyMatcher:
                 # Partial soundex similarity
                 seq_sim = SequenceMatcher(None, soundex1, soundex2).ratio()
                 similarities.append(seq_sim)
-        except:
-            pass
-            
+        except Exception as exc:
+            logger.debug("Soundex comparison failed: %s", exc)
+
         # Metaphone comparison
         try:
             metaphone1 = self._get_metaphone(norm1)
@@ -242,62 +247,112 @@ class FuzzyMatcher:
             else:
                 seq_sim = SequenceMatcher(None, metaphone1, metaphone2).ratio()
                 similarities.append(seq_sim)
-        except:
-            pass
-            
+        except Exception as exc:
+            logger.debug("Metaphone comparison failed: %s", exc)
+
         return max(similarities) if similarities else 0.0
-        
+
     def _get_soundex(self, text: str) -> str:
         """Get Soundex encoding with caching."""
         if text in self._soundex_cache:
             return self._soundex_cache[text]
-            
+
         try:
-            soundex = jellyfish.soundex(text)
+            soundex = jellyfish.soundex(text) if HAS_JELLYFISH else self._basic_soundex(text)
             self._soundex_cache[text] = soundex
             return soundex
-        except:
+        except Exception as exc:
+            logger.debug("Soundex generation failed for '%s': %s", text, exc)
             return ""
-            
+
     def _get_metaphone(self, text: str) -> str:
         """Get Metaphone encoding with caching."""
         if text in self._metaphone_cache:
             return self._metaphone_cache[text]
-            
+
         try:
-            metaphone = jellyfish.metaphone(text)
+            metaphone = jellyfish.metaphone(text) if HAS_JELLYFISH else self._basic_metaphone(text)
             self._metaphone_cache[text] = metaphone
             return metaphone
-        except:
+        except Exception as exc:
+            logger.debug("Metaphone generation failed for '%s': %s", text, exc)
             return ""
-            
+
+    def _basic_soundex(self, text: str) -> str:
+        """Simple Soundex implementation used as a fallback."""
+        text = re.sub(r"[^A-Za-z]", "", text).upper()
+        if not text:
+            return ""
+        first = text[0]
+        mapping = {
+            "B": "1",
+            "F": "1",
+            "P": "1",
+            "V": "1",
+            "C": "2",
+            "G": "2",
+            "J": "2",
+            "K": "2",
+            "Q": "2",
+            "S": "2",
+            "X": "2",
+            "Z": "2",
+            "D": "3",
+            "T": "3",
+            "L": "4",
+            "M": "5",
+            "N": "5",
+            "R": "6",
+        }
+        encoded = [mapping.get(ch, "") for ch in text[1:]]
+        result = [first]
+        prev = mapping.get(first, "")
+        for code in encoded:
+            if code != prev and code != "":
+                result.append(code)
+            prev = code
+        result = "".join(result).ljust(4, "0")[:4]
+        return result
+
+    def _basic_metaphone(self, text: str) -> str:
+        """Very small Metaphone-like fallback implementation."""
+        text = re.sub(r"[^A-Za-z]", "", text).lower()
+        if not text:
+            return ""
+        # drop duplicate adjacent letters
+        deduped = [text[0]]
+        for ch in text[1:]:
+            if ch != deduped[-1]:
+                deduped.append(ch)
+        text = "".join(deduped)
+        # remove vowels except first letter
+        first = text[0]
+        remainder = re.sub(r"[aeiou]", "", text[1:])
+        return (first + remainder)[:4].upper()
+
     def find_best_match(
-        self, 
-        query: str, 
-        candidates: List[str], 
-        text_type: str = "general",
-        min_score: float = None
+        self, query: str, candidates: List[str], text_type: str = "general", min_score: float = None
     ) -> Optional[FuzzyMatch]:
         """Find the best fuzzy match from a list of candidates."""
         if not query or not candidates:
             return None
-            
+
         min_score = min_score or self.min_similarity_threshold
         best_match = None
         best_score = 0.0
-        
+
         for candidate in candidates:
             # Calculate combined similarity
             string_sim = self.calculate_similarity(query, candidate)
             phonetic_sim = self.phonetic_similarity(query, candidate)
-            
+
             # Weighted combination
             combined_score = string_sim * 0.8 + phonetic_sim * 0.2
-            
+
             if combined_score > best_score and combined_score >= min_score:
                 best_score = combined_score
                 method = "combined" if phonetic_sim > 0 else "string"
-                
+
                 best_match = FuzzyMatch(
                     original=query,
                     matched=candidate,
@@ -306,32 +361,32 @@ class FuzzyMatcher:
                     normalized_original=self.normalize_text(query, text_type),
                     normalized_matched=self.normalize_text(candidate, text_type),
                 )
-                
+
         return best_match
-        
+
     def find_all_matches(
-        self, 
-        query: str, 
-        candidates: List[str], 
+        self,
+        query: str,
+        candidates: List[str],
         text_type: str = "general",
         min_score: float = None,
-        max_results: int = 10
+        max_results: int = 10,
     ) -> List[FuzzyMatch]:
         """Find all matches above threshold, sorted by score."""
         if not query or not candidates:
             return []
-            
+
         min_score = min_score or self.min_similarity_threshold
         matches = []
-        
+
         for candidate in candidates:
             string_sim = self.calculate_similarity(query, candidate)
             phonetic_sim = self.phonetic_similarity(query, candidate)
             combined_score = string_sim * 0.8 + phonetic_sim * 0.2
-            
+
             if combined_score >= min_score:
                 method = "combined" if phonetic_sim > 0 else "string"
-                
+
                 match = FuzzyMatch(
                     original=query,
                     matched=candidate,
@@ -341,45 +396,43 @@ class FuzzyMatcher:
                     normalized_matched=self.normalize_text(candidate, text_type),
                 )
                 matches.append(match)
-                
+
         # Sort by score descending
         matches.sort(key=lambda x: x.score, reverse=True)
         return matches[:max_results]
-        
+
     def match_artist_song_pair(
-        self, 
-        query_artist: str, 
+        self,
+        query_artist: str,
         query_song: str,
         candidate_pairs: List[Tuple[str, str]],
-        min_score: float = None
+        min_score: float = None,
     ) -> Optional[Tuple[FuzzyMatch, FuzzyMatch]]:
         """Match artist-song pairs with combined scoring."""
         if not query_artist or not query_song or not candidate_pairs:
             return None
-            
+
         min_score = min_score or self.min_similarity_threshold
         best_match = None
         best_combined_score = 0.0
-        
+
         for candidate_artist, candidate_song in candidate_pairs:
             # Match both artist and song
             artist_match = self.find_best_match(
                 query_artist, [candidate_artist], "artist", min_score=0.5
             )
-            song_match = self.find_best_match(
-                query_song, [candidate_song], "song", min_score=0.5
-            )
-            
+            song_match = self.find_best_match(query_song, [candidate_song], "song", min_score=0.5)
+
             if artist_match and song_match:
                 # Combined score with artist weighted higher
                 combined_score = artist_match.score * 0.6 + song_match.score * 0.4
-                
+
                 if combined_score > best_combined_score and combined_score >= min_score:
                     best_combined_score = combined_score
                     best_match = (artist_match, song_match)
-                    
+
         return best_match
-        
+
     def get_statistics(self) -> Dict:
         """Get fuzzy matching statistics."""
         return {
@@ -391,9 +444,9 @@ class FuzzyMatcher:
                 "similarity": self.min_similarity_threshold,
                 "phonetic": self.min_phonetic_threshold,
                 "edit_distance": self.max_edit_distance,
-            }
+            },
         }
-        
+
     def clear_caches(self):
         """Clear all internal caches."""
         self._normalization_cache.clear()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ click>=8.1.0
 PyYAML>=6.0
 tenacity>=8.2.0
 tqdm>=4.66.0
+jellyfish==1.0.0

--- a/tests/test_fuzzy_matcher.py
+++ b/tests/test_fuzzy_matcher.py
@@ -1,0 +1,29 @@
+import importlib
+
+from collector.search import fuzzy_matcher
+
+
+class DummyConfig:
+    def __init__(self):
+        self.fuzzy_matching = {"min_similarity": 0.5}
+
+
+def test_config_handling_object():
+    fm = fuzzy_matcher.FuzzyMatcher(DummyConfig())
+    assert fm.min_similarity_threshold == 0.5
+
+
+def test_normalization_cache_key_by_type():
+    fm = fuzzy_matcher.FuzzyMatcher()
+    fm.clear_caches()
+    fm.normalize_text("The Beatles", text_type="artist")
+    fm.normalize_text("The Beatles", text_type="song")
+    assert len(fm._normalization_cache) == 2
+
+
+def test_phonetic_fallback_without_jellyfish(monkeypatch):
+    monkeypatch.setattr(fuzzy_matcher, "HAS_JELLYFISH", False)
+    fm = fuzzy_matcher.FuzzyMatcher()
+    sim = fm.phonetic_similarity("Catherine", "Katherine")
+    assert sim > 0
+    importlib.reload(fuzzy_matcher)


### PR DESCRIPTION
## Summary
- add jellyfish dependency
- fix configuration lookup and caching in fuzzy matcher
- implement fallback phonetic algorithms when jellyfish unavailable
- tighten exception handling and cap token bonus
- add tests for fuzzy matcher functionality
- ensure SearchEngine fallback provides helper methods
- adjust DB schema version handling and processor metadata fallback

## Testing
- `python -m flake8`
- `black --check collector/search/fuzzy_matcher.py collector/search/__init__.py tests/test_fuzzy_matcher.py collector/processor.py collector/db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eca2a5dc4832ca759950667e3e422