### PR TITLE
Add pytest-cov support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,14 +206,14 @@ The collector creates a normalized SQLite database with the following tables:
 ## Development
 
 ```bash
-# Install development dependencies
+# Install development dependencies (includes pytest-cov for coverage)
 pip install -e ".[dev]"
 
 # Keep yt-dlp updated for YouTube API changes
 pip install --upgrade yt-dlp
 
 # Run tests with coverage
-pytest
+pytest --cov=collector
 
 # Run linting with auto-fix
 ruff check . --fix
@@ -232,8 +232,9 @@ pre-commit install
 
 The project uses several tools to maintain code quality:
 
-- **pytest** - Testing framework with coverage reporting
-- **ruff** - Fast Python linter with auto-fix capabilities  
+- **pytest** - Testing framework
+- **pytest-cov** - Coverage reporting plugin for pytest
+- **ruff** - Fast Python linter with auto-fix capabilities
 - **black** - Code formatting for consistent style
 - **Pylance/mypy** - Type checking for better code reliability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
+    "pytest-cov>=4.1.0",
     "ruff>=0.1.0",
     "black>=23.0.0",
     "pre-commit>=3.0.0",


### PR DESCRIPTION
## Summary
- add `pytest-cov` to optional dev dependencies
- mention pytest-cov usage in README development instructions
- recommend running tests with coverage

## Testing
- `pytest -q`
- `ruff check .`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_685ee65ad89c832c87f6e2cc26678a85