### PR TITLE
Add database pool settings support

### DIFF
--- a/collector/config.py
+++ b/collector/config.py
@@ -36,6 +36,8 @@ class DatabaseConfig:
     backup_retention_days: int = 7
     vacuum_threshold_mb: int = 100
     vacuum_on_startup: bool = False
+    connection_pool_size: int = 10
+    connection_timeout: float = 30.0
 
 
 @dataclass

--- a/collector/db.py
+++ b/collector/db.py
@@ -28,8 +28,8 @@ class DatabaseManager:
         # Connection pool to prevent connection exhaustion
         self._connection_pool = []
         self._pool_lock = threading.Lock()
-        self._max_pool_size = 10
-        self._pool_timeout = 30.0
+        self._max_pool_size = config.connection_pool_size
+        self._pool_timeout = config.connection_timeout
 
         self.setup_database()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,3 +79,18 @@ def test_validation_error(tmp_path):
     )
     with pytest.raises(ValueError):
         load_config(str(cfg_path))
+
+
+def test_custom_database_pool_settings(tmp_path):
+    cfg_path = tmp_path / "pool.yaml"
+    cfg_path.write_text(
+        """
+        database:
+          connection_pool_size: 5
+          connection_timeout: 5.5
+        """
+    )
+
+    cfg = load_config(str(cfg_path))
+    assert cfg.database.connection_pool_size == 5
+    assert cfg.database.connection_timeout == 5.5

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -167,3 +167,17 @@ def test_validation_table_and_insert(tmp_path):
             "SELECT artist_valid, song_valid, validation_score, suggested_title FROM validation_results WHERE video_id='vid1'"
         ).fetchone()
         assert row == (1, 0, 0.6, "X")
+
+
+def test_pool_settings_applied(tmp_path):
+    db_path = tmp_path / "pool.db"
+    cfg = DatabaseConfig(
+        path=str(db_path),
+        backup_enabled=False,
+        connection_pool_size=3,
+        connection_timeout=5.0,
+    )
+
+    dbm = DatabaseManager(cfg)
+    assert dbm._max_pool_size == 3
+    assert dbm._pool_timeout == 5.0


### PR DESCRIPTION
## Summary
- add `connection_pool_size` and `connection_timeout` to `DatabaseConfig`
- apply these settings in `DatabaseManager`
- test loading custom pool config values
- test DatabaseManager uses provided pool settings

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0a43bbd0832c9150f8654059e64e