### PR TITLE
Add configurable logging options

### DIFF
--- a/collector/cli.py
+++ b/collector/cli.py
@@ -124,11 +124,6 @@ def cli():
 def collect(config, queries, max_per_query, output_db, verbose, dry_run, multi_strategy):
     """Collect karaoke videos from YouTube."""
 
-    # Setup logging
-    log_level = logging.DEBUG if verbose else logging.INFO
-    setup_logging(level=log_level)
-
-    # Load configuration
     if config:
         collector_config = load_config(config)
     else:
@@ -141,6 +136,16 @@ def collect(config, queries, max_per_query, output_db, verbose, dry_run, multi_s
         collector_config.dry_run = True
     if multi_strategy:
         collector_config.search.use_multi_strategy = True
+
+    log_cfg = collector_config.logging
+    log_level = logging.DEBUG if verbose else getattr(logging, log_cfg.level.upper(), logging.INFO)
+    setup_logging(
+        level=log_level,
+        log_file=log_cfg.file_path,
+        max_bytes=log_cfg.max_file_size_mb * 1024 * 1024,
+        backup_count=log_cfg.backup_count,
+        console_output=log_cfg.console_output,
+    )
 
     # Default queries if none provided
     if not queries:
@@ -179,7 +184,6 @@ def collect(config, queries, max_per_query, output_db, verbose, dry_run, multi_s
 )
 def collect_channel(channel_url, config, max_videos, no_incremental, log_level, multi_strategy):
     """Collect karaoke videos from a specific YouTube channel."""
-    setup_logging(getattr(logging, log_level.upper()))
 
     if config:
         collector_config = load_config(config)
@@ -188,6 +192,18 @@ def collect_channel(channel_url, config, max_videos, no_incremental, log_level, 
 
     if multi_strategy:
         collector_config.search.use_multi_strategy = True
+
+    log_cfg = collector_config.logging
+    level = getattr(logging, log_level.upper()) if log_level else getattr(
+        logging, log_cfg.level.upper(), logging.INFO
+    )
+    setup_logging(
+        level=level,
+        log_file=log_cfg.file_path,
+        max_bytes=log_cfg.max_file_size_mb * 1024 * 1024,
+        backup_count=log_cfg.backup_count,
+        console_output=log_cfg.console_output,
+    )
 
     collector = KaraokeCollector(collector_config)
 
@@ -218,12 +234,23 @@ def collect_channel(channel_url, config, max_videos, no_incremental, log_level, 
 @click.option("--log-level", default="INFO", help="Logging level")
 def collect_channels(channels_file, config, max_videos, log_level):
     """Collect karaoke videos from multiple channels (one URL per line in file)."""
-    setup_logging(getattr(logging, log_level.upper()))
 
     if config:
         collector_config = load_config(config)
     else:
         collector_config = CollectorConfig()
+
+    log_cfg = collector_config.logging
+    level = getattr(logging, log_level.upper()) if log_level else getattr(
+        logging, log_cfg.level.upper(), logging.INFO
+    )
+    setup_logging(
+        level=level,
+        log_file=log_cfg.file_path,
+        max_bytes=log_cfg.max_file_size_mb * 1024 * 1024,
+        backup_count=log_cfg.backup_count,
+        console_output=log_cfg.console_output,
+    )
 
     # Read channel URLs from file
     try:

--- a/collector/utils.py
+++ b/collector/utils.py
@@ -5,29 +5,49 @@ import sys
 from logging.handlers import RotatingFileHandler
 
 
-def setup_logging(level=logging.INFO, log_file="karaoke_collector.log"):
-    """Setup comprehensive logging configuration."""
+def setup_logging(
+    level: int = logging.INFO,
+    log_file: str = "karaoke_collector.log",
+    max_bytes: int = 50 * 1024 * 1024,
+    backup_count: int = 5,
+    console_output: bool = True,
+) -> None:
+    """Setup comprehensive logging configuration.
 
-    # Create formatter
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    Parameters
+    ----------
+    level: int
+        Logging level.
+    log_file: str
+        Path to the log file.
+    max_bytes: int
+        Maximum size in bytes before rotating the log file.
+    backup_count: int
+        Number of rotated log files to keep.
+    console_output: bool
+        Whether to also log to the console.
+    """
 
-    # Setup file handler with rotation
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(level)
+
     file_handler = RotatingFileHandler(
-        log_file, maxBytes=50 * 1024 * 1024, backupCount=5  # 50MB max, 5 backups
+        log_file, maxBytes=max_bytes, backupCount=backup_count
     )
     file_handler.setLevel(level)
     file_handler.setFormatter(formatter)
-
-    # Setup console handler
-    console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(level)
-    console_handler.setFormatter(formatter)
-
-    # Configure root logger
-    root_logger = logging.getLogger()
-    root_logger.setLevel(level)
     root_logger.addHandler(file_handler)
-    root_logger.addHandler(console_handler)
+
+    if console_output:
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setLevel(level)
+        console_handler.setFormatter(formatter)
+        root_logger.addHandler(console_handler)
 
     # Suppress noisy third-party loggers
     logging.getLogger("yt_dlp").setLevel(logging.WARNING)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,22 @@ from collector.utils import setup_logging
 
 def test_setup_logging(tmp_path):
     log_file = tmp_path / "test.log"
-    setup_logging(level=logging.DEBUG, log_file=str(log_file))
+    setup_logging(
+        level=logging.DEBUG,
+        log_file=str(log_file),
+        max_bytes=1024,
+        backup_count=2,
+        console_output=False,
+    )
     logger = logging.getLogger()
-    assert any(isinstance(h, logging.StreamHandler) for h in logger.handlers)
-    assert any(isinstance(h, logging.handlers.RotatingFileHandler) for h in logger.handlers)
+    file_handlers = [
+        h for h in logger.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]
+    assert len(file_handlers) == 1
+    handler = file_handlers[0]
+    assert handler.maxBytes == 1024
+    assert handler.backupCount == 2
+    logger.info("hello")
+    with open(log_file, "r") as f:
+        data = f.read()
+    assert "hello" in data


### PR DESCRIPTION
## Summary
- allow `setup_logging` to configure rotation and console output
- wire up CLI to use logging settings from `CollectorConfig`
- test new logging behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0a450860832c8488129fed4db1dd