### PR TITLE
Implement channel operations for multi strategy engine

### DIFF
--- a/collector/enhanced_search.py
+++ b/collector/enhanced_search.py
@@ -401,6 +401,22 @@ class MultiStrategySearchEngine:
             logger.error(f"Performance optimization failed: {e}")
             return {"error": str(e)}
 
+    async def extract_channel_info(self, channel_url: str) -> Dict:
+        """Retrieve channel information using the primary provider."""
+        provider = self.providers.get("youtube")
+        if not provider:
+            return {}
+        return await provider.extract_channel_info(channel_url)
+
+    async def extract_channel_videos(
+        self, channel_url: str, max_videos: Optional[int] = None, after_date: Optional[str] = None
+    ) -> List[SearchResult]:
+        """Retrieve videos from a channel using the primary provider."""
+        provider = self.providers.get("youtube")
+        if not provider:
+            return []
+        return await provider.extract_channel_videos(channel_url, max_videos, after_date)
+
     async def search_with_fallback_strategies(
         self, query: str, max_results: int = 100
     ) -> List[SearchResult]:

--- a/collector/main.py
+++ b/collector/main.py
@@ -5,6 +5,9 @@ import logging
 import signal
 import time
 from typing import Any, Dict, List, Optional
+from dataclasses import asdict
+
+from .search.providers.base import SearchResult
 
 from .config import CollectorConfig
 from .db import DatabaseManager
@@ -344,6 +347,10 @@ class KaraokeCollector:
             video_list = await self.search_engine.extract_channel_videos(
                 channel_url, max_videos, after_date
             )
+
+            # Convert SearchResult objects to dictionaries for processing
+            if video_list and isinstance(video_list[0], SearchResult):
+                video_list = [asdict(v) for v in video_list]
 
             if not video_list:
                 logger.warning(f"No videos found in channel: {channel_data.get('channel_name')}")


### PR DESCRIPTION
## Summary
- support channel info and video listing in `MultiStrategySearchEngine`
- convert `SearchResult` instances before batch processing
- test collecting from channel using multi strategy search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0dd5781c832ca581125d07d118c2