### PR TITLE
Handle missing tenacity

### DIFF
--- a/collector/processor.py
+++ b/collector/processor.py
@@ -58,6 +58,10 @@ try:
     from tenacity import retry, stop_after_attempt, wait_exponential  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency
 
+    class _DummyWait:
+        def __add__(self, other):
+            return self
+
     def retry(*dargs, **dkwargs):
         def _decorator(fn):
             return fn
@@ -68,14 +72,14 @@ except ImportError:  # pragma: no cover - optional dependency
         return None
 
     def wait_exponential(*args, **kwargs):
-        return None
+        return _DummyWait()
 
+
+from typing import TYPE_CHECKING
 
 from .advanced_parser import AdvancedTitleParser, ParseResult
 from .config import CollectorConfig
 from .validation_corrector import ValidationCorrector
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from .multi_pass_controller import MultiPassParsingController

--- a/collector/search/providers/youtube.py
+++ b/collector/search/providers/youtube.py
@@ -16,6 +16,10 @@ try:
     from tenacity import retry, stop_after_attempt, wait_exponential, wait_random  # type: ignore
 except ImportError:
 
+    class _DummyWait:
+        def __add__(self, other):
+            return self
+
     def retry(*dargs, **dkwargs):
         def _decorator(fn):
             return fn
@@ -26,10 +30,10 @@ except ImportError:
         return None
 
     def wait_exponential(*args, **kwargs):
-        return None
+        return _DummyWait()
 
     def wait_random(*args, **kwargs):
-        return None
+        return _DummyWait()
 
 
 from ...config import ScrapingConfig

--- a/collector/search_engine.py
+++ b/collector/search_engine.py
@@ -16,6 +16,10 @@ try:
     from tenacity import retry, stop_after_attempt, wait_exponential, wait_random  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency
 
+    class _DummyWait:
+        def __add__(self, other):
+            return self
+
     def retry(*dargs, **dkwargs):
         def _decorator(fn):
             return fn
@@ -26,10 +30,10 @@ except ImportError:  # pragma: no cover - optional dependency
         return None
 
     def wait_exponential(*args, **kwargs):
-        return None
+        return _DummyWait()
 
     def wait_random(*args, **kwargs):
-        return None
+        return _DummyWait()
 
 
 from .config import ScrapingConfig, SearchConfig


### PR DESCRIPTION
## Summary
- add dummy wait helpers for missing tenacity
- return dummy objects in wait stubs
- reload search modules without tenacity in tests

## Testing
- `ruff check --fix collector/search_engine.py collector/search/providers/youtube.py collector/processor.py tests/test_search.py`
- `black collector/search_engine.py collector/search/providers/youtube.py collector/processor.py tests/test_search.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f10dfa078832c85573b1fd0b64b77