### PR TITLE
Fix import order

### DIFF
--- a/collector/main.py
+++ b/collector/main.py
@@ -4,15 +4,14 @@ import asyncio
 import logging
 import signal
 import time
-from typing import Any, Dict, List, Optional
 from dataclasses import asdict
-
-from .search.providers.base import SearchResult
+from typing import Any, Dict, List, Optional
 
 from .config import CollectorConfig
 from .db import DatabaseManager
 from .enhanced_search import MultiStrategySearchEngine
 from .processor import VideoProcessor
+from .search.providers.base import SearchResult
 from .search_engine import SearchEngine
 
 try:

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -3,14 +3,13 @@
 import asyncio
 import sqlite3
 from pathlib import Path
-
-from collector.config import CollectorConfig
-from collector.db import DatabaseConfig, DatabaseManager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-from collector.processor import ProcessingResult, VideoProcessor
 from collector.advanced_parser import ParseResult
+from collector.config import CollectorConfig
+from collector.db import DatabaseConfig, DatabaseManager
+from collector.processor import ProcessingResult, VideoProcessor
 
 
 def test_extract_karaoke_features():


### PR DESCRIPTION
## Summary
- run `ruff --fix` to sort imports in `collector/main.py` and `tests/test_processor.py`

## Testing
- `ruff check collector/main.py tests/test_processor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f12b1ab00832c870b9ee267d8bcbe