### PR TITLE
Fix formatting for CLI and tests

### DIFF
--- a/collector/cli.py
+++ b/collector/cli.py
@@ -196,7 +196,9 @@ def collect(
     is_flag=True,
     help="Enable multi-pass parsing system",
 )
-def collect_channel(channel_url, config, max_videos, no_incremental, log_level, multi_strategy, multi_pass):
+def collect_channel(
+    channel_url, config, max_videos, no_incremental, log_level, multi_strategy, multi_pass
+):
     """Collect karaoke videos from a specific YouTube channel."""
 
     if config:
@@ -210,8 +212,10 @@ def collect_channel(channel_url, config, max_videos, no_incremental, log_level, 
         collector_config.search.multi_pass.enabled = True
 
     log_cfg = collector_config.logging
-    level = getattr(logging, log_level.upper()) if log_level else getattr(
-        logging, log_cfg.level.upper(), logging.INFO
+    level = (
+        getattr(logging, log_level.upper())
+        if log_level
+        else getattr(logging, log_cfg.level.upper(), logging.INFO)
     )
     setup_logging(
         level=level,
@@ -257,8 +261,10 @@ def collect_channels(channels_file, config, max_videos, log_level):
         collector_config = CollectorConfig()
 
     log_cfg = collector_config.logging
-    level = getattr(logging, log_level.upper()) if log_level else getattr(
-        logging, log_cfg.level.upper(), logging.INFO
+    level = (
+        getattr(logging, log_level.upper())
+        if log_level
+        else getattr(logging, log_cfg.level.upper(), logging.INFO)
     )
     setup_logging(
         level=level,

--- a/collector/main.py
+++ b/collector/main.py
@@ -46,9 +46,13 @@ class KaraokeCollector:
             from .multi_pass_controller import MultiPassParsingController
 
             search_engine_for_mp = (
-                self.search_engine if isinstance(self.search_engine, MultiStrategySearchEngine) else None
+                self.search_engine
+                if isinstance(self.search_engine, MultiStrategySearchEngine)
+                else None
             )
-            advanced_parser = self.video_processor.advanced_parser or AdvancedTitleParser(config.search)
+            advanced_parser = self.video_processor.advanced_parser or AdvancedTitleParser(
+                config.search
+            )
             self.multi_pass_controller = MultiPassParsingController(
                 config.search.multi_pass,
                 advanced_parser,
@@ -119,9 +123,7 @@ class KaraokeCollector:
                 async with self._processed_ids_lock:
                     old_size = len(self.processed_video_ids)
                     # Keep recent database IDs and retain any previously processed IDs
-                    self.processed_video_ids = recent_ids.union(
-                        self.processed_video_ids
-                    )
+                    self.processed_video_ids = recent_ids.union(self.processed_video_ids)
                     # Enforce hard limit
                     if len(self.processed_video_ids) > self._memory_cache_limit:
                         self.processed_video_ids = set(

--- a/collector/utils.py
+++ b/collector/utils.py
@@ -28,17 +28,13 @@ def setup_logging(
         Whether to also log to the console.
     """
 
-    formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
     root_logger = logging.getLogger()
     root_logger.handlers.clear()
     root_logger.setLevel(level)
 
-    file_handler = RotatingFileHandler(
-        log_file, maxBytes=max_bytes, backupCount=backup_count
-    )
+    file_handler = RotatingFileHandler(log_file, maxBytes=max_bytes, backupCount=backup_count)
     file_handler.setLevel(level)
     file_handler.setFormatter(formatter)
     root_logger.addHandler(file_handler)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -199,5 +199,7 @@ def test_migrations_applied(tmp_path):
         assert "recording_length_ms" in columns
 
         # Migration 7 introduces search cache table
-        tables = {row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        tables = {
+            row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
         assert "search_cache" in tables

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -285,9 +285,7 @@ def test_process_video_uses_multi_pass(monkeypatch):
     mpr = SimpleNamespace()
     mpr.parse_video = AsyncMock(
         return_value=SimpleNamespace(
-            final_result=ParseResult(
-                original_artist="A", song_title="S", confidence=0.9
-            )
+            final_result=ParseResult(original_artist="A", song_title="S", confidence=0.9)
         )
     )
 


### PR DESCRIPTION
## Summary
- run `black` on CLI module, main engine, and utils
- reformat test fixtures to satisfy linting

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f13b04570832c83557c43f96bfbd2