### PR TITLE
Fix migration and video saving

### DIFF
--- a/collector/db.py
+++ b/collector/db.py
@@ -702,7 +702,9 @@ INSERT OR REPLACE INTO schema_info(version) VALUES (7);
                     like_dislike_ratio = None
                     views = video_data.get("view_count", 0)
                     likes = video_data.get("like_count", 0)
-                    dislikes = video_data.get("estimated_dislikes", 0)
+                    dislikes = video_data.get("estimated_dislikes")
+                    if dislikes is None:
+                        dislikes = 0
 
                     if views > 0:
                         like_dislike_ratio = (likes - dislikes) / views
@@ -733,7 +735,7 @@ INSERT OR REPLACE INTO schema_info(version) VALUES (7);
                             video_data.get("upload_date"),
                             video_data.get("thumbnail"),
                             video_data.get("uploader"),
-                            video_data.get("uploader_id"),
+                            video_data.get("uploader_id") or None,
                             features.get("original_artist"),
                             features.get("featured_artists"),
                             features.get("song_title"),

--- a/collector/processor.py
+++ b/collector/processor.py
@@ -246,7 +246,7 @@ class VideoProcessor:
                 "comment_count": info.get("comment_count") or 0,
                 "upload_date": info.get("upload_date") or "",
                 "uploader": info.get("uploader") or "",
-                "uploader_id": info.get("uploader_id") or "",
+                "uploader_id": info.get("uploader_id") or None,
                 "thumbnail": info.get("thumbnail") or "",
                 "tags": info.get("tags") or [],
                 "formats": info.get("formats") or [],

--- a/migrations/005_add_foreign_keys.sql
+++ b/migrations/005_add_foreign_keys.sql
@@ -119,7 +119,6 @@ CREATE INDEX IF NOT EXISTS idx_videos_video_id ON videos(video_id);
 CREATE INDEX IF NOT EXISTS idx_videos_channel_id ON videos(channel_id);
 CREATE INDEX IF NOT EXISTS idx_videos_upload_date ON videos(upload_date);
 CREATE INDEX IF NOT EXISTS idx_videos_view_count ON videos(view_count);
-CREATE INDEX IF NOT EXISTS idx_videos_created_at ON videos(created_at);
 CREATE INDEX IF NOT EXISTS idx_videos_artist_song ON videos(original_artist, song_title);
 
 -- Recreate the trigger for the new table


### PR DESCRIPTION
## Summary
- handle `None` dislikes when saving videos
- drop non-existent `created_at` index from migration 005
- handle missing channel IDs when processing videos

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f21592854832cb2007d36b91e0022